### PR TITLE
Update correlation-id version to support async-await

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/toboid/express-correlation-id#readme",
   "dependencies": {
-    "correlation-id": "^2.0.0"
+    "correlation-id": "^2.1.1"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
@toboid can you please release a new version from `express-correlation-id` as well ?